### PR TITLE
GOVERNANCE.md Proposal

### DIFF
--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -1,0 +1,198 @@
+# Core Developer Guide
+
+Welcome, new core developer!  The core team appreciate the quality of
+your work, and enjoy working with you; we have therefore invited you
+to join us.  Thank you for your numerous contributions to the project
+so far.
+
+You can see a list of all the current core developers on our
+[@napari/core-devs](https://github.com/orgs/napari/teams/core-devs)
+GitHub team. You should now be on that list too.
+
+This document offers guidelines for your new role.  First and
+foremost, you should familiarize yourself with the project's
+[mission and values](MISSION_AND_VALUES.md).  When in
+doubt, always refer back there.
+
+As a core team member, you gain the responsibility of shepherding
+other contributors through the review process; here are some
+guidelines for how to do that.
+
+## All Contributors Are Treated The Same
+
+As a core developer, you gain the ability to merge or approve
+other contributors' pull requests.  Much like nuclear launch keys, it
+is a shared power: you must merge *only after* another core has
+approved the pull request, *and* after you yourself have carefully
+reviewed it.  (See [Reviewing](#reviewing) and especially
+[Merge Only Changes You Understand](#merge-only-changes-you-understand) below.)
+It should also be considered best practice to leave a reasonable (24hr) time window
+after approval before merge to ensure that other core developers have a reasonable
+chance to weigh in.
+
+We are also an international community, with contributors from many different time zones,
+some of whom will only contribute during their working hours, others who might only be able
+to contribute during nights and weekends. It is important to be respectful of other peoples
+schedules and working habits, even if it slows the project down slightly - we are in this
+for the long run. In the same vein you also shouldn't feel pressured to be constantly
+available or online, and users or contributors who are overly demanding and unreasonable
+to the point of harassment will be directed to our [Code of Conduct](CODE_OF_CONDUCT.md).
+We value sustainable development practices over mad rushes.
+
+When merging, use GitHub's
+[Squash and Merge](https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-on-github)
+to ensure a clean git history.
+
+You should also continue to make your own pull requests as before and in accordance
+with the [general contributor guide](CONTRIBUTING.md). These pull requests still
+require the approval of another core developer before they can be merged.
+
+## Reviewing
+
+### How to Conduct A Good Review
+
+*Always* be kind to contributors. Contributors are often doing
+volunteer work, for which we are tremendously grateful. Provide
+constructive criticism on ideas and implementations, and remind
+yourself of how it felt when your own work was being evaluated as a
+novice.
+
+`napari` strongly values mentorship in code review.  New users
+often need more handholding, having little to no git
+experience. Repeat yourself liberally, and, if you don’t recognize a
+contributor, point them to our development guide, or other GitHub
+workflow tutorials around the web. Do not assume that they know how
+GitHub works (many don't realize that adding a commit
+automatically updates a pull request, for example). Gentle, polite, kind
+encouragement can make the difference between a new core developer and
+an abandoned pull request.
+
+When reviewing, focus on the following:
+
+1. **Usability and generality:** `napari` is a GUI application that strives to be accessible
+to both coding and non-coding users, and new features should ultimately be
+accessible to everyone using the app. `napari` targets the scientific user
+community broadly, and core features should be domain-agnostic and general purpose.
+Custom functionality is meant to be provided through our plugin ecosystem. If in doubt,
+consult back with our [mission and values](MISSION_AND_VALUES.md).
+
+2. **Performance and benchmarks:** As `napari` targets scientific applications that often involve
+large multidimensional datasets, high performance is a key value of `napari`. While
+every new feature won't scale equally to all sizes of data, keeping in mind performance
+and our [benchmarks](BENCHMARKS.md) during a review may be important, and you may
+need to ask for benchmarks to be run and reported or new benchmarks to be added.
+
+3. **APIs and stability:** Coding users and plugin developers will make
+extensive use of our APIs. The foundation of a healthy plugin ecosystem will be
+a fully capable and stable set of APIs, so as `napari` matures it will
+very important to ensure our APIs are stable. For now, while the project is still
+in an earlier stage, spending the extra time to consider names of public facing
+variables and methods, along side function signatures, could save us considerable
+trouble in the future. Right now we are still making breaking changes with minor
+version numbers `0.x` and do not have a deprecation policy, but we will work to add one soon.
+
+4. **Documentation and tutorials:** All new methods should have appropriate doc
+strings following [PEP257](https://www.python.org/dev/peps/pep-0257/) and the
+[NumPy documentation guide](https://docs.scipy.org/doc/numpy/docs/howto_document.html).
+For any major new features, accompanying changes should be made to our
+[tutorials repository](https://github.com/napari/napari-tutorials), that not only
+illustrates the new feature, but explains it.
+
+5. **Implementations and algorithms:** You should understand the code being modified
+or added before approving it.  (See [Merge Only Changes You Understand](#merge-only-changes-you-understand)
+below.) Implementations should do what they claim and be simple, readable, and efficient
+in that order.
+
+6. **Tests:** All contributions *must* be tested, and each added line of code
+should be covered by at least one test. Good tests not only execute the code,
+but explore corner cases.  It can be tempting not to review tests, but please
+do so.
+
+Other changes may be *nitpicky*: spelling mistakes, formatting,
+etc. Do not insist contributors make these changes, but instead you should offer
+to make these changes by [pushing to their branch](https://help.github.com/articles/committing-changes-to-a-pull-request-branch-created-from-a-fork/), or using GitHub’s [suggestion](https://help.github.com/articles/commenting-on-a-pull-request/)
+[feature](https://help.github.com/articles/incorporating-feedback-in-your-pull-request/), and
+be prepared to make them yourself if needed. Using the suggestion feature is preferred because
+it gives the contributor a choice in whether to accept the changes.
+
+Unless you know that a contributor is experienced with git, don’t
+ask for a rebase when merge conflicts arise. Instead, rebase the
+branch yourself, force-push to their branch, and advise the contributor to force-pull.  If the contributor is
+no longer active, you may take over their branch by submitting a new pull
+request and closing the original, including a reference to the original pull
+request. In doing so, ensure you communicate that you are not throwing the
+contributor's work away!
+
+### Merge Only Changes You Understand
+
+*Long-term maintainability* is an important concern.  Code doesn't
+merely have to *work*, but should be *understood* by multiple core
+developers.  Changes will have to be made in the future, and the
+original contributor may have moved on.
+
+Therefore, *do not merge a code change unless you understand it*. Ask
+for help freely: we can consult community members, or even external developers,
+for added insight where needed, and see this as a great learning opportunity.
+
+While we collectively "own" any patches (and bugs!) that become part
+of the code base, you are vouching for changes you merge.  Please take
+that responsibility seriously.
+
+## Further resources
+
+As a core member, you should be familiar with community and developer
+resources such as:
+
+-  Our [contributor guide](CONTRIBUTING.md).
+-  Our [code of conduct](CODE_OF_CONDUCT.md).
+-  Our [governance](GOVERNANCE.md).
+-  Our [mission and values](MISSION_AND_VALUES.md).
+-  Our [benchmarking guide](BENCHMARKS.md).
+-  [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python style.
+-  [PEP257](https://www.python.org/dev/peps/pep-0257/) and the
+   [NumPy documentation guide](https://docs.scipy.org/doc/numpy/docs/howto_document.html)
+   for docstring conventions.
+-  [`pre-commit`](https://pre-commit.com) hooks for autoformatting.
+-  [`black`](https://github.com/psf/black) autoformatting.
+-  [`flake8`](https://github.com/PyCQA/flake8) linting.
+-  [#napari on image.sc](https://forum.image.sc/tags/napari).
+-  [#napari](https://twitter.com/search?q=%23napari&f=live) and [@napari_imaging](https://twitter.com/napari_imaging) on twitter.
+-  [napari zulip](https://napari.zulipchat.com/) community chat channel.
+
+You are not required to monitor the social resources.
+
+Where possible we prefer to point people towards asynchronous forms of communication
+like forum posts and github issues instead of realtime chat options as they are easier
+for a global community to consume.
+
+We also have a private mailing list for core developers
+`napari-core-devs@googlegroups.com` which is sparingly used for discussions
+that are required to be private, such as voting on new core members.
+
+## Inviting New Core Members
+
+Any core member may nominate other contributors to join the core team.
+While there is no hard-and-fast rule about who can be nominated, ideally,
+they should have: been part of the project for at least two months, contributed
+significant changes of their own, contributed to the discussion and
+review of others' work, and collaborated in a way befitting our
+community values. After nomination voting will happen on a private mailing list.
+While it is expected that most votes will be unanimous, a two-thirds majority of
+the cast votes is enough.
+
+Core developers can choose to become emeritus core developers and suspend
+their approval and voting rights until they become active again.
+
+## Contribute To This Guide!
+
+This guide reflects the experience of the current core developers.  We
+may well have missed things that, by now, have become second
+nature—things that you, as a new team member, will spot more easily.
+Please ask the other core developers if you have any questions, and
+submit a pull request with insights gained.
+
+## Conclusion
+
+We are excited to have you on board!  We look forward to your
+contributions to the code base and the community.  Thank you in
+advance!

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -18,7 +18,7 @@ guidelines for how to do that.
 
 As a core developer, you gain the ability to merge or approve
 other contributors' pull requests.  Much like nuclear launch keys, it
-is a shared power: you must merge *only after* another core has
+is a shared power: you may merge your own PRs *only after* another core has
 approved the pull request, *and* after you yourself have carefully
 reviewed it.  (See [Reviewing](#reviewing) and especially
 [Merge Only Changes You Understand](#merge-only-changes-you-understand) below.)

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -6,7 +6,7 @@ to join us.  Thank you for your numerous contributions to the project
 so far.
 
 You can see a list of all the current core developers on our
-[@napari/core-devs](https://github.com/orgs/napari/teams/core-devs)
+[@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs)
 GitHub team. You should now be on that list too.
 
 This document offers guidelines for your new role.  First and
@@ -57,7 +57,7 @@ constructive criticism on ideas and implementations, and remind
 yourself of how it felt when your own work was being evaluated as a
 novice.
 
-`napari` strongly values mentorship in code review.  New users
+`zarr` strongly values mentorship in code review.  New users
 often need more handholding, having little to no git
 experience. Repeat yourself liberally, and, if you don’t recognize a
 contributor, point them to our development guide, or other GitHub
@@ -69,22 +69,22 @@ an abandoned pull request.
 
 When reviewing, focus on the following:
 
-1. **Usability and generality:** `napari` is a GUI application that strives to be accessible
+1. **Usability and generality:** `zarr` is a GUI application that strives to be accessible
 to both coding and non-coding users, and new features should ultimately be
-accessible to everyone using the app. `napari` targets the scientific user
+accessible to everyone using the app. `zarr` targets the scientific user
 community broadly, and core features should be domain-agnostic and general purpose.
 Custom functionality is meant to be provided through our plugin ecosystem. If in doubt,
 consult back with our [mission and values](MISSION_AND_VALUES.md).
 
-2. **Performance and benchmarks:** As `napari` targets scientific applications that often involve
-large multidimensional datasets, high performance is a key value of `napari`. While
+2. **Performance and benchmarks:** As `zarr` targets scientific applications that often involve
+large multidimensional datasets, high performance is a key value of `zarr`. While
 every new feature won't scale equally to all sizes of data, keeping in mind performance
 and our [benchmarks](BENCHMARKS.md) during a review may be important, and you may
 need to ask for benchmarks to be run and reported or new benchmarks to be added.
 
 3. **APIs and stability:** Coding users and plugin developers will make
 extensive use of our APIs. The foundation of a healthy plugin ecosystem will be
-a fully capable and stable set of APIs, so as `napari` matures it will
+a fully capable and stable set of APIs, so as `zarr` matures it will
 very important to ensure our APIs are stable. For now, while the project is still
 in an earlier stage, spending the extra time to consider names of public facing
 variables and methods, along side function signatures, could save us considerable
@@ -95,7 +95,7 @@ version numbers `0.x` and do not have a deprecation policy, but we will work to 
 strings following [PEP257](https://www.python.org/dev/peps/pep-0257/) and the
 [NumPy documentation guide](https://docs.scipy.org/doc/numpy/docs/howto_document.html).
 For any major new features, accompanying changes should be made to our
-[tutorials repository](https://github.com/napari/napari-tutorials), that not only
+[tutorials repository](https://github.com/zarr-developers/zarr-developers-tutorials), that not only
 illustrates the new feature, but explains it.
 
 5. **Implementations and algorithms:** You should understand the code being modified

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -16,15 +16,17 @@ guidelines for how to do that.
 
 ## All Contributors Are Treated The Same
 
-As a core developer, you gain the ability to merge or approve
+As a core developer, you gain the ability to approve and merge
 other contributors' pull requests.  Much like nuclear launch keys, it
-is a shared power: you may merge your own PRs *only after* another core has
-approved the pull request, *and* after you yourself have carefully
-reviewed it.  (See [Reviewing](#reviewing) and especially
-[Merge Only Changes You Understand](#merge-only-changes-you-understand) below.)
+is a shared power: see [Reviewing](#reviewing) and especially
+[Merge Only Changes You Understand](#merge-only-changes-you-understand) below.
 It should also be considered best practice to leave a reasonable (24hr) time window
 after approval before merge to ensure that other core developers have a reasonable
 chance to weigh in.
+
+You may of course also continue to make your own pull requests as before and in accordance
+with the [general contributor guide](https://github.com/zarr-developers/.github/blob/master/CONTRIBUTING.md).
+These pull requests require the approval of another core developer before they can be merged.
 
 We are also an international community, with contributors from many different time zones,
 some of whom will only contribute during their working hours, others who might only be able
@@ -39,10 +41,6 @@ We value sustainable development practices over mad rushes.
 When merging, use GitHub's
 [Squash and Merge](https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-on-github)
 to ensure a clean git history.
-
-You should also continue to make your own pull requests as before and in accordance
-with the [general contributor guide](https://github.com/zarr-developers/.github/blob/master/CONTRIBUTING.md).
-These pull requests still require the approval of another core developer before they can be merged.
 
 ## Reviewing
 

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -66,7 +66,7 @@ an abandoned pull request.
 
 When reviewing, focus on the following:
 
-1. **Usability and generality:** `Zarr` is a GUI application that strives to be accessible
+1. **Usability and generality:** `Zarr` is a library that strives to be accessible
 to both coding and non-coding users, and new features should ultimately be
 accessible to everyone using the app. `Zarr` targets the scientific user
 community broadly, and core features should be domain-agnostic and general purpose.
@@ -75,17 +75,13 @@ Custom functionality is meant to be provided through our plugin ecosystem.
 2. **Performance and benchmarks:** As `Zarr` targets scientific applications that often involve
 large multidimensional datasets, high performance is a key value of `Zarr`. While
 every new feature won't scale equally to all sizes of data, keeping in mind performance
-and our [benchmarks](BENCHMARKS.md) during a review may be important, and you may
+during a review may be important, and you may
 need to ask for benchmarks to be run and reported or new benchmarks to be added.
 
 3. **APIs and stability:** Coding users and plugin developers will make
-extensive use of our APIs. The foundation of a healthy plugin ecosystem will be
-a fully capable and stable set of APIs, so as `Zarr` matures it will
-very important to ensure our APIs are stable. For now, while the project is still
-in an earlier stage, spending the extra time to consider names of public facing
-variables and methods, along side function signatures, could save us considerable
-trouble in the future. Right now we are still making breaking changes with minor
-version numbers `0.x` and do not have a deprecation policy, but we will work to add one soon.
+extensive use of our APIs. The foundation of a healthy ecosystem will be
+a fully capable and stable set of APIs, so it is important 
+important to ensure our APIs are stable.
 
 4. **Documentation and tutorials:** All new methods should have appropriate doc
 strings following [PEP257](https://www.python.org/dev/peps/pep-0257/) and the
@@ -142,7 +138,6 @@ resources such as:
 -  Our [contributor guide](https://github.com/zarr-developers/.github/blob/master/CONTRIBUTING.md).
 -  Our [code of conduct](https://github.com/zarr-developers/.github/blob/master/CODE_OF_CONDUCT.md).
 -  Our [governance](GOVERNANCE.md).
--  Our [benchmarking guide](BENCHMARKS.md).
 -  [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python style.
 -  [PEP257](https://www.python.org/dev/peps/pep-0257/) and the
    [NumPy documentation guide](https://docs.scipy.org/doc/numpy/docs/howto_document.html)
@@ -150,9 +145,7 @@ resources such as:
 -  [`pre-commit`](https://pre-commit.com) hooks for autoformatting.
 -  [`black`](https://github.com/psf/black) autoformatting.
 -  [`flake8`](https://github.com/PyCQA/flake8) linting.
--  [#napari on image.sc](https://forum.image.sc/tags/napari).
--  [#napari](https://twitter.com/search?q=%23napari&f=live) and [@napari_imaging](https://twitter.com/napari_imaging) on twitter.
--  [napari zulip](https://napari.zulipchat.com/) community chat channel.
+-  [#zarr_dev](https://twitter.com/search?q=%23zarr_dev&f=live) on twitter.
 
 You are not required to monitor the social resources.
 
@@ -160,9 +153,8 @@ Where possible we prefer to point people towards asynchronous forms of communica
 like forum posts and github issues instead of realtime chat options as they are easier
 for a global community to consume.
 
-We also have a private mailing list for core developers
-`napari-core-devs@googlegroups.com` which is sparingly used for discussions
-that are required to be private, such as voting on new core members.
+We also make use of private messages via the GitHub team (@zarr-developers/core-devs)
+sparingly for discussions that are required to be private, such as voting on new core members.
 
 ## Inviting New Core Members
 

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -54,7 +54,7 @@ constructive criticism on ideas and implementations, and remind
 yourself of how it felt when your own work was being evaluated as a
 novice.
 
-`zarr` strongly values mentorship in code review.  New users
+`Zarr` strongly values mentorship in code review.  New users
 often need more handholding, having little to no git
 experience. Repeat yourself liberally, and, if you don’t recognize a
 contributor, point them to our development guide, or other GitHub
@@ -66,21 +66,21 @@ an abandoned pull request.
 
 When reviewing, focus on the following:
 
-1. **Usability and generality:** `zarr` is a GUI application that strives to be accessible
+1. **Usability and generality:** `Zarr` is a GUI application that strives to be accessible
 to both coding and non-coding users, and new features should ultimately be
-accessible to everyone using the app. `zarr` targets the scientific user
+accessible to everyone using the app. `Zarr` targets the scientific user
 community broadly, and core features should be domain-agnostic and general purpose.
 Custom functionality is meant to be provided through our plugin ecosystem.
 
-2. **Performance and benchmarks:** As `zarr` targets scientific applications that often involve
-large multidimensional datasets, high performance is a key value of `zarr`. While
+2. **Performance and benchmarks:** As `Zarr` targets scientific applications that often involve
+large multidimensional datasets, high performance is a key value of `Zarr`. While
 every new feature won't scale equally to all sizes of data, keeping in mind performance
 and our [benchmarks](BENCHMARKS.md) during a review may be important, and you may
 need to ask for benchmarks to be run and reported or new benchmarks to be added.
 
 3. **APIs and stability:** Coding users and plugin developers will make
 extensive use of our APIs. The foundation of a healthy plugin ecosystem will be
-a fully capable and stable set of APIs, so as `zarr` matures it will
+a fully capable and stable set of APIs, so as `Zarr` matures it will
 very important to ensure our APIs are stable. For now, while the project is still
 in an earlier stage, spending the extra time to consider names of public facing
 variables and methods, along side function signatures, could save us considerable

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -32,7 +32,8 @@ to contribute during nights and weekends. It is important to be respectful of ot
 schedules and working habits, even if it slows the project down slightly - we are in this
 for the long run. In the same vein you also shouldn't feel pressured to be constantly
 available or online, and users or contributors who are overly demanding and unreasonable
-to the point of harassment will be directed to our [Code of Conduct](CODE_OF_CONDUCT.md).
+to the point of harassment will be directed to our
+[Code of Conduct](https://github.com/zarr-developers/.github/blob/master/CODE_OF_CONDUCT.md).
 We value sustainable development practices over mad rushes.
 
 When merging, use GitHub's
@@ -40,8 +41,8 @@ When merging, use GitHub's
 to ensure a clean git history.
 
 You should also continue to make your own pull requests as before and in accordance
-with the [general contributor guide](CONTRIBUTING.md). These pull requests still
-require the approval of another core developer before they can be merged.
+with the [general contributor guide](https://github.com/zarr-developers/.github/blob/master/CONTRIBUTING.md).
+These pull requests still require the approval of another core developer before they can be merged.
 
 ## Reviewing
 
@@ -138,8 +139,8 @@ that responsibility seriously.
 As a core member, you should be familiar with community and developer
 resources such as:
 
--  Our [contributor guide](CONTRIBUTING.md).
--  Our [code of conduct](CODE_OF_CONDUCT.md).
+-  Our [contributor guide](https://github.com/zarr-developers/.github/blob/master/CONTRIBUTING.md).
+-  Our [code of conduct](https://github.com/zarr-developers/.github/blob/master/CODE_OF_CONDUCT.md).
 -  Our [governance](GOVERNANCE.md).
 -  Our [benchmarking guide](BENCHMARKS.md).
 -  [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python style.

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -9,11 +9,7 @@ You can see a list of all the current core developers on our
 [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs)
 GitHub team. You should now be on that list too.
 
-This document offers guidelines for your new role.  First and
-foremost, you should familiarize yourself with the project's
-[mission and values](MISSION_AND_VALUES.md).  When in
-doubt, always refer back there.
-
+This document offers guidelines for your new role.
 As a core team member, you gain the responsibility of shepherding
 other contributors through the review process; here are some
 guidelines for how to do that.
@@ -73,8 +69,7 @@ When reviewing, focus on the following:
 to both coding and non-coding users, and new features should ultimately be
 accessible to everyone using the app. `zarr` targets the scientific user
 community broadly, and core features should be domain-agnostic and general purpose.
-Custom functionality is meant to be provided through our plugin ecosystem. If in doubt,
-consult back with our [mission and values](MISSION_AND_VALUES.md).
+Custom functionality is meant to be provided through our plugin ecosystem.
 
 2. **Performance and benchmarks:** As `zarr` targets scientific applications that often involve
 large multidimensional datasets, high performance is a key value of `zarr`. While
@@ -146,7 +141,6 @@ resources such as:
 -  Our [contributor guide](CONTRIBUTING.md).
 -  Our [code of conduct](CODE_OF_CONDUCT.md).
 -  Our [governance](GOVERNANCE.md).
--  Our [mission and values](MISSION_AND_VALUES.md).
 -  Our [benchmarking guide](BENCHMARKS.md).
 -  [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python style.
 -  [PEP257](https://www.python.org/dev/peps/pep-0257/) and the

--- a/CORE_DEV_GUIDE.md
+++ b/CORE_DEV_GUIDE.md
@@ -55,8 +55,8 @@ yourself of how it felt when your own work was being evaluated as a
 novice.
 
 `Zarr` strongly values mentorship in code review.  New users
-often need more handholding, having little to no git
-experience. Repeat yourself liberally, and, if you don’t recognize a
+often need more hand-holding, having little to no git
+experience. Repeat yourself liberally, and, if you don't recognize a
 contributor, point them to our development guide, or other GitHub
 workflow tutorials around the web. Do not assume that they know how
 GitHub works (many don't realize that adding a commit

--- a/DIVERSITY.md
+++ b/DIVERSITY.md
@@ -1,0 +1,8 @@
+Diversity and Inclusion
+=======================
+
+The Zarr developer community welcomes and encourages participation by everyone.
+Our community is based on mutual respect, tolerance, and encouragement, and we
+are working to help each other live up to these principles. We want our
+community to be more diverse: whoever you are, and whatever your background, we
+welcome you.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,149 @@
+# Abstract
+
+The purpose of this document is to formalize the governance process used by the
+`napari` project, to clarify how decisions are made and how the various
+elements of our community interact.
+
+This is a consensus-based community project. Anyone with an interest in the
+project can join the community, contribute to the project design, and
+participate in the decision making process. This document describes how that
+participation takes place, how to find consensus, and how deadlocks are
+resolved.
+
+# Roles And Responsibilities
+
+## The Community
+
+The napari community consists of anyone using or working with the project
+in any way.
+
+## Contributors
+
+A community member can become a contributor by interacting directly with the
+project in concrete ways, such as:
+
+- proposing a change to the code via a GitHub
+  [GitHub pull request](https://github.com/napari/napari/pulls);
+- reporting issues on our
+  [GitHub issues page](https://github.com/napari/napari/issues);
+- proposing a change to the documentation, or
+  [tutorials](https://github.com/napari/napari-tutorials) via a
+  GitHub pull request;
+- discussing the design of the napari or its tutorials on in existing
+  [issues](https://github.com/napari/napari/issues) and
+  [pull requests](https://github.com/napari/napari/pulls);
+- discussing examples or use cases on the
+  [image.sc forum](https://forum.image.sc/tags/napari) under the #napari tag; or
+- reviewing [open pull requests](https://github.com/napari/napari/pulls)
+
+among other possibilities. Any community member can become a contributor, and
+all are encouraged to do so. By contributing to the project, community members
+can directly help to shape its future.
+
+Contributors are encouraged to read the [contributing guide](CONTRIBUTING.md).
+
+## Core developers
+
+Core developers are community members that have demonstrated continued
+commitment to the project through ongoing contributions. They
+have shown they can be trusted to maintain napari with care. Becoming a
+core developer allows contributors to merge approved pull requests, cast votes
+for and against merging a pull-request, and be involved in deciding major
+changes to the API, and thereby more easily carry on with their project related
+activities. Core developers appear as organization members on the napari
+[GitHub organization](https://github.com/orgs/napari/people) and are on our
+[@napari/core-devs](https://github.com/orgs/napari/teams/core-devs) GitHub team. Core
+developers are expected to review code contributions while adhering to the
+[core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
+by any existing core developer, and for details on that process see our core
+developer guide.
+
+## Steering Council
+
+The Steering Council (SC) members are core developers who have additional
+responsibilities to ensure the smooth running of the project. SC members are
+expected to participate in strategic planning, approve changes to the
+governance model, and make decisions about funding granted to the project
+itself. (Funding to community members is theirs to pursue and manage). The
+purpose of the SC is to ensure smooth progress from the big-picture
+perspective. Changes that impact the full project require analysis informed by
+long experience with both the project and the larger ecosystem. When the core
+developer community (including the SC members) fails to reach such a consensus
+in a reasonable timeframe, the SC is the entity that resolves the issue.
+
+Members of the steering council also have the "owner" role within the [napari GitHub organization](https://github.com/napari/)
+and are ultimately responsible for managing the napari GitHub account, the [@napari_imaging](https://twitter.com/napari_imaging)
+twitter account, the [napari website](http://napari.org), and other similar napari owned resources.
+
+The steering council is currently fixed in size to three members. This number may be increased in
+the future, but will always be an odd number to ensure a simple majority vote outcome
+is always possible. The initial steering council of napari consists of
+
+* [Juan Nunez-Iglesias](https://github.com/jni)
+
+* [Loic Royer](https://github.com/royerloic)
+
+* [Nicholas Sofroniew](https://github.com/sofroniewn)
+
+The SC membership is revisited every January. SC members who do
+not actively engage with the SC duties are expected to resign. New members are
+added by nomination by a core developer. Nominees should have demonstrated
+long-term, continued commitment to the project and its [mission and values](MISSION_AND_VALUES.md). A
+nomination will result in discussion that cannot take more than a month and
+then admission to the SC by consensus. During that time deadlocked votes of the SC will
+be postponed until the new member has joined and another vote can be held.
+
+The napari steering council may be contacted at `napari-steering-council@googlegroups.com`.
+Or via the [@napari/steering-council](https://github.com/orgs/napari/teams/steering-council) GitHub team.
+
+# Decision Making Process
+
+Decisions about the future of the project are made through discussion with all
+members of the community. All non-sensitive project management discussion takes
+place on the [issue tracker](https://github.com/napari/napari/issues) and project
+[zulip](https://napari.zulipchat.com/) community chat channel. Occasionally,
+sensitive discussion may occur on a private core developer mailing list
+`napari-core-devs@googlegroups.com` or private chat channel.
+
+Decisions should be made in accordance with the [mission and values](MISSION_AND_VALUES.md)
+of the napari project.
+
+napari uses a “consensus seeking” process for making decisions. The group
+tries to find a resolution that has no open objections among core developers.
+Core developers are expected to distinguish between fundamental objections to a
+proposal and minor perceived flaws that they can live with, and not hold up the
+decision-making process for the latter.  If no option can be found without
+objections, the decision is escalated to the SC, which will itself use
+consensus seeking to come to a resolution. In the unlikely event that there is
+still a deadlock, the proposal will move forward if it has the support of a
+simple majority of the SC.
+
+Decisions (in addition to adding core developers and SC membership as above)
+are made according to the following rules:
+
+- **Minor documentation changes**, such as typo fixes, or addition / correction of a
+  sentence, require approval by a core developer *and* no disagreement or requested
+  changes by a core developer on the issue or pull request page (lazy
+  consensus). Core developers are expected to give “reasonable time” to others
+  to give their opinion on the pull request if they’re not confident others
+  would agree.
+
+- **Code changes and major documentation changes** require agreement by *one*
+  core developer *and* no disagreement or requested changes by a core developer
+  on the issue or pull-request page (lazy consensus). For all changes of this type,
+  core developers are expected to give “reasonable time” after approval and before
+  merging for others to weigh in on the pull request in its final state.
+
+- **Changes to the API principles** require a dedicated issue on our
+  [issue tracker](https://github.com/napari/napari/issues) and follow the
+  decision-making process outlined above.
+
+- **Changes to this governance model or our mission, vision, and values**
+  require a  dedicated issue on our [issue tracker](https://github.com/napari/napari/issues)
+  and follow the decision-making process outlined above,
+  *unless* there is unanimous agreement from core developers on the change in
+  which case it can move forward faster.
+
+If an objection is raised on a lazy consensus, the proposer can appeal to the
+community and core developers and the change can be approved or rejected by
+escalating to the SC.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -86,7 +86,7 @@ is always possible. The initial steering council of zarr consists of
 The SC membership is revisited every January. SC members who do
 not actively engage with the SC duties are expected to resign. New members are
 added by nomination by a core developer. Nominees should have demonstrated
-long-term, continued commitment to the project and its [mission and values](MISSION_AND_VALUES.md). A
+long-term, continued commitment to the project and its mission and values. A
 nomination will result in discussion that cannot take more than a month and
 then admission to the SC by consensus. During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held.
@@ -104,8 +104,7 @@ Occasionally, sensitive discussion may occur on a private core developer mailing
 
 TBD: Alternative is via https://github.com/orgs/zarr-developers/teams/core-devs
 
-Decisions should be made in accordance with the [mission and values](MISSION_AND_VALUES.md)
-of the zarr project.
+Decisions should be made in accordance with the mission and values of the zarr project.
 
 zarr uses a “consensus seeking” process for making decisions. The group
 tries to find a resolution that has no open objections among core developers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Abstract
 
 The purpose of this document is to formalize the governance process used by the
-`napari` project, to clarify how decisions are made and how the various
+`zarr` project, to clarify how decisions are made and how the various
 elements of our community interact.
 
 This is a consensus-based community project. Anyone with an interest in the
@@ -14,7 +14,7 @@ resolved.
 
 ## The Community
 
-The napari community consists of anyone using or working with the project
+The zarr community consists of anyone using or working with the project
 in any way.
 
 ## Contributors
@@ -22,19 +22,12 @@ in any way.
 A community member can become a contributor by interacting directly with the
 project in concrete ways, such as:
 
-- proposing a change to the code via a GitHub
-  [GitHub pull request](https://github.com/napari/napari/pulls);
-- reporting issues on our
-  [GitHub issues page](https://github.com/napari/napari/issues);
-- proposing a change to the documentation, or
-  [tutorials](https://github.com/napari/napari-tutorials) via a
-  GitHub pull request;
-- discussing the design of the napari or its tutorials on in existing
-  [issues](https://github.com/napari/napari/issues) and
-  [pull requests](https://github.com/napari/napari/pulls);
-- discussing examples or use cases on the
-  [image.sc forum](https://forum.image.sc/tags/napari) under the #napari tag; or
-- reviewing [open pull requests](https://github.com/napari/napari/pulls)
+- proposing, discussing, or reviewing a change to the code, documentation, or specification
+  via a GitHub pull request to any https://github.com/zarr-developers repository;
+- reporting a GitHub issue
+  to any https://github.com/zarr-developers repository;
+- discussing examples or usage issues under the #zarr tag on StackOverflow 
+  (like "How do I do X in zarr?").
 
 among other possibilities. Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members
@@ -46,13 +39,13 @@ Contributors are encouraged to read the [contributing guide](CONTRIBUTING.md).
 
 Core developers are community members that have demonstrated continued
 commitment to the project through ongoing contributions. They
-have shown they can be trusted to maintain napari with care. Becoming a
+have shown they can be trusted to maintain zarr with care. Becoming a
 core developer allows contributors to merge approved pull requests, cast votes
 for and against merging a pull-request, and be involved in deciding major
 changes to the API, and thereby more easily carry on with their project related
-activities. Core developers appear as organization members on the napari
-[GitHub organization](https://github.com/orgs/napari/people) and are on our
-[@napari/core-devs](https://github.com/orgs/napari/teams/core-devs) GitHub team. Core
+activities. Core developers appear as organization members on the zarr
+[GitHub organization](https://github.com/orgs/zarr-developers/people) and are on our
+[@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team. Core
 developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
 by any existing core developer, and for details on that process see our core
@@ -71,19 +64,23 @@ long experience with both the project and the larger ecosystem. When the core
 developer community (including the SC members) fails to reach such a consensus
 in a reasonable timeframe, the SC is the entity that resolves the issue.
 
-Members of the steering council also have the "owner" role within the [napari GitHub organization](https://github.com/napari/)
-and are ultimately responsible for managing the napari GitHub account, the [@napari_imaging](https://twitter.com/napari_imaging)
-twitter account, the [napari website](http://napari.org), and other similar napari owned resources.
+Members of the steering council also have the "owner" role within the [zarr-developersGitHub organization](https://github.com/zarr-developers/)
+and are ultimately responsible for managing the zarr-developers GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
+twitter account, the [zarr website]( https://zarr-developers.github.io), and other similar zarr owned resources.
 
-The steering council is currently fixed in size to three members. This number may be increased in
+The steering council is currently fixed in size to five members. This number may be increased in
 the future, but will always be an odd number to ensure a simple majority vote outcome
-is always possible. The initial steering council of napari consists of
+is always possible. The initial steering council of zarr consists of
 
-* [Juan Nunez-Iglesias](https://github.com/jni)
+* [Ryan Abernathy](https://github.com/rabernat)
 
-* [Loic Royer](https://github.com/royerloic)
+* [John Kirkham](https://github.com/jakirkham)
 
-* [Nicholas Sofroniew](https://github.com/sofroniewn)
+* [Alistair Miles](https://github.com/alimanfoo)
+
+* [Josh Moore](https://github.com/joshmoore)
+
+* [Ryan Williams](https://github.com/ryan-williams)
 
 The SC membership is revisited every January. SC members who do
 not actively engage with the SC duties are expected to resign. New members are
@@ -93,22 +90,23 @@ nomination will result in discussion that cannot take more than a month and
 then admission to the SC by consensus. During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held.
 
-The napari steering council may be contacted at `napari-steering-council@googlegroups.com`.
-Or via the [@napari/steering-council](https://github.com/orgs/napari/teams/steering-council) GitHub team.
+The zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`.
+Or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team.
 
 # Decision Making Process
 
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
-place on the [issue tracker](https://github.com/napari/napari/issues) and project
-[zulip](https://napari.zulipchat.com/) community chat channel. Occasionally,
-sensitive discussion may occur on a private core developer mailing list
-`napari-core-devs@googlegroups.com` or private chat channel.
+place on the issue trackers of the https://github.com/zarr-developers repositories.
+Occasionally, sensitive discussion may occur on a private core developer mailing list
+`zarr-core-devs@googlegroups.com` or private chat channel.
+
+TBD: Alternative is via https://github.com/orgs/zarr-developers/teams/core-devs
 
 Decisions should be made in accordance with the [mission and values](MISSION_AND_VALUES.md)
-of the napari project.
+of the zarr project.
 
-napari uses a “consensus seeking” process for making decisions. The group
+zarr uses a “consensus seeking” process for making decisions. The group
 tries to find a resolution that has no open objections among core developers.
 Core developers are expected to distinguish between fundamental objections to a
 proposal and minor perceived flaws that they can live with, and not hold up the
@@ -135,11 +133,11 @@ are made according to the following rules:
   merging for others to weigh in on the pull request in its final state.
 
 - **Changes to the API principles** require a dedicated issue on our
-  [issue tracker](https://github.com/napari/napari/issues) and follow the
-  decision-making process outlined above.
+  [issue tracker](https://github.com/zarr-developers/zarr-python/issues) and follow the
+  decision-making process outlined above. (TBD: unclear if this repo suffices)
 
 - **Changes to this governance model or our mission, vision, and values**
-  require a  dedicated issue on our [issue tracker](https://github.com/napari/napari/issues)
+  require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)
   and follow the decision-making process outlined above,
   *unless* there is unanimous agreement from core developers on the change in
   which case it can move forward faster.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -66,7 +66,7 @@ developer community (including the SC members) fails to reach such a consensus
 in a reasonable timeframe, the SC is the entity that resolves the issue.
 
 Members of the steering council also have the "owner" role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
-and are ultimately responsible for managing the zarr-developers GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
+and are ultimately responsible for managing the [zarr-developers](https://github.com/zarr-developers) GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
 twitter account, the [zarr website]( https://zarr-developers.github.io), and other similar zarr owned resources.
 
 The steering council is currently fixed in size to five members. This number may be increased in

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -145,6 +145,11 @@ are made according to the following rules:
   decision-making process outlined above, though "reasonable time" is likely extended
   to at least a week.
 
+- **Changes to the specification** require a dedicated issue on our
+  [issue tracker](https://github.com/zarr-developers/zarr-specs/issues) and follow the
+  decision-making process outlined above, though "reasonable time" is likely extended
+  to at least two weeks.
+
 - **Changes to this governance model or our mission, vision, and values**
   require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)
   and follow the decision-making process outlined above, with "reasonable time" being

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,25 +122,27 @@ are made according to the following rules:
 - **Minor documentation changes**, such as typo fixes, or addition / correction of a
   sentence, require approval by a core developer *and* no disagreement or requested
   changes by a core developer on the issue or pull request page (lazy
-  consensus). Core developers are expected to give “reasonable time” to others
+  consensus). Core developers are expected to give "reasonable time" to others
   to give their opinion on the pull request if they’re not confident others
-  would agree.
+  would agree, where "reasonable time" is likely double-digit hours.
 
 - **Code changes and major documentation changes** require agreement by *one*
   core developer *and* no disagreement or requested changes by a core developer
   on the issue or pull-request page (lazy consensus). For all changes of this type,
-  core developers are expected to give “reasonable time” after approval and before
-  merging for others to weigh in on the pull request in its final state.
+  core developers are expected to give "reasonable time" after approval and before
+  merging for others to weigh in on the pull request in its final state, where
+  "reasonable time" is likely a few working days.
 
-- **Changes to the API principles** require a dedicated issue on our
+- **Changes to the Python API principles** require a dedicated issue on our
   [issue tracker](https://github.com/zarr-developers/zarr-python/issues) and follow the
-  decision-making process outlined above. (TBD: unclear if this repo suffices)
+  decision-making process outlined above, though "reasonable time" is likely extended
+  to at least a week.
 
 - **Changes to this governance model or our mission, vision, and values**
   require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)
-  and follow the decision-making process outlined above,
-  *unless* there is unanimous agreement from core developers on the change in
-  which case it can move forward faster.
+  and follow the decision-making process outlined above, with "reasonable time" being
+  at least two weeks. However, if there is unanimous agreement from core developers on the change,
+  it can move forward faster.
 
 If an objection is raised on a lazy consensus, the proposer can appeal to the
 community and core developers and the change can be approved or rejected by

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -140,15 +140,14 @@ are made according to the following rules:
   merging for others to weigh in on the pull request in its final state, where
   "reasonable time" is likely a few working days.
 
-- **Changes to the Python API principles** require a dedicated issue on our
-  [issue tracker](https://github.com/zarr-developers/zarr-python/issues) and follow the
+- **Changes to APIs ** require a dedicated issue on the related
+  issue tracker, e.g. [zarr-python](https://github.com/zarr-developers/zarr-python/issues), and follow the
   decision-making process outlined above, though "reasonable time" is likely extended
   to at least a week.
 
 - **Changes to the specification** require a dedicated issue on our
-  [issue tracker](https://github.com/zarr-developers/zarr-specs/issues) and follow the
-  decision-making process outlined above, though "reasonable time" is likely extended
-  to at least two weeks.
+  [issue tracker](https://github.com/zarr-developers/zarr-specs/issues) and even more
+  time than an API change. The appropriate length of time is currently under discussion.
 
 - **Changes to this governance model or our mission, vision, and values**
   require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -120,9 +120,9 @@ are made according to the following rules:
 - **Minor documentation changes**, such as typo fixes, or addition / correction of a
   sentence, require approval by a core developer *and* no disagreement or requested
   changes by a core developer on the issue or pull request page (lazy
-  consensus). Core developers are expected to give "reasonable time" to others
+  consensus). Core developers are expected to give "reasonable time" after approval and before merging for others
   to give their opinion on the pull request if they’re not confident others
-  would agree, where "reasonable time" is likely double-digit hours.
+  would agree, where "reasonable time" is likely one working day.
 
 - **Code changes and major documentation changes** require agreement by *one*
   core developer *and* no disagreement or requested changes by a core developer

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Abstract
 
 The purpose of this document is to formalize the governance process used by the
-`zarr` project, to clarify how decisions are made and how the various
+`Zarr` project, to clarify how decisions are made and how the various
 elements of our community interact.
 
 This is a consensus-based community project. Anyone with an interest in the
@@ -27,7 +27,7 @@ project in concrete ways, such as:
 - reporting a GitHub issue
   to any https://github.com/zarr-developers repository;
 - discussing examples or usage issues under the #zarr tag on StackOverflow 
-  (like "How do I do X in zarr?").
+  (like "How do I do X in Zarr?").
 
 among other possibilities. Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members
@@ -40,11 +40,11 @@ for information about contributing to Zarr.
 
 Core developers are community members that have demonstrated continued
 commitment to the project through ongoing contributions. They
-have shown they can be trusted to maintain zarr with care. Becoming a
+have shown they can be trusted to maintain Zarr with care. Becoming a
 core developer allows contributors to merge approved pull requests, cast votes
 for and against merging a pull-request, and be involved in deciding major
 changes to the API, and thereby more easily carry on with their project related
-activities. Core developers appear as organization members on the zarr
+activities. Core developers appear as organization members on the Zarr
 [GitHub organization](https://github.com/orgs/zarr-developers/people) and are on our
 [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team. Core
 developers are expected to review code contributions while adhering to the
@@ -67,11 +67,11 @@ in a reasonable timeframe, the SC is the entity that resolves the issue.
 
 Members of the steering council also have the "owner" role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
 and are ultimately responsible for managing the [zarr-developers](https://github.com/zarr-developers) GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
-twitter account, the [zarr website]( https://zarr-developers.github.io), and other similar zarr owned resources.
+twitter account, the [Zarr website]( https://zarr-developers.github.io), and other similar Zarr-owned resources.
 
 The steering council is currently fixed in size to five members. This number may be increased in
 the future, but will always be an odd number to ensure a simple majority vote outcome
-is always possible. The initial steering council of zarr consists of
+is always possible. The initial steering council of Zarr consists of
 
 * [Ryan Abernathey](https://github.com/rabernat)
 
@@ -91,7 +91,7 @@ nomination will result in discussion that cannot take more than a month and
 then admission to the SC by consensus. During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held.
 
-The zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`.
+The Zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`.
 Or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team.
 
 # Decision Making Process
@@ -104,9 +104,9 @@ Occasionally, sensitive discussion may occur on a private core developer mailing
 
 TBD: Alternative is via https://github.com/orgs/zarr-developers/teams/core-devs
 
-Decisions should be made in accordance with the mission and values of the zarr project.
+Decisions should be made in accordance with the mission and values of the Zarr project.
 
-zarr uses a “consensus seeking” process for making decisions. The group
+Zarr uses a “consensus seeking” process for making decisions. The group
 tries to find a resolution that has no open objections among core developers.
 Core developers are expected to distinguish between fundamental objections to a
 proposal and minor perceived flaws that they can live with, and not hold up the

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,7 +64,7 @@ long experience with both the project and the larger ecosystem. When the core
 developer community (including the SC members) fails to reach such a consensus
 in a reasonable timeframe, the SC is the entity that resolves the issue.
 
-Members of the steering council also have the "owner" role within the [zarr-developersGitHub organization](https://github.com/zarr-developers/)
+Members of the steering council also have the "owner" role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
 and are ultimately responsible for managing the zarr-developers GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
 twitter account, the [zarr website]( https://zarr-developers.github.io), and other similar zarr owned resources.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -91,18 +91,16 @@ nomination will result in discussion that cannot take more than a month and
 then admission to the SC by consensus. During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held.
 
-The Zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`.
-Or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team.
+The Zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`,
+or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team.
 
 # Decision Making Process
 
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
 place on the issue trackers of the https://github.com/zarr-developers repositories.
-Occasionally, sensitive discussion may occur on a private core developer mailing list
-`zarr-core-devs@googlegroups.com` or private chat channel.
-
-TBD: Alternative is via https://github.com/orgs/zarr-developers/teams/core-devs
+Occasionally, sensitive discussion may occur via a private message via the GitHub team:
+https://github.com/orgs/zarr-developers/teams/core-devs
 
 Decisions should be made in accordance with the mission and values of the Zarr project.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,7 +14,7 @@ resolved.
 
 ## The Community
 
-The zarr community consists of anyone using or working with the project
+The Zarr community consists of anyone using or working with the project
 in any way.
 
 ## Contributors

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,7 +33,8 @@ among other possibilities. Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members
 can directly help to shape its future.
 
-Contributors are encouraged to read the [contributing guide](CONTRIBUTING.md).
+Contributors are encouraged to read the [contributing guide](http://zarr.readthedocs.io/en/stable/contributing.html)
+for information about contributing to Zarr.
 
 ## Core developers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,8 +33,17 @@ among other possibilities. Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members
 can directly help to shape its future.
 
-Contributors are encouraged to read the [contributing guide](http://zarr.readthedocs.io/en/stable/contributing.html)
-for information about contributing to Zarr.
+Potential contributors are encouraged to read the [Contributing Guide](http://zarr.readthedocs.io/en/stable/contributing.html)
+as well as the [Code of Conduct](https://github.com/zarr-developers/.github/blob/master/CODE_OF_CONDUCT.md).
+
+A community member becomes a contributor when the following criteria are met:
+
+- At least two core developers from separate employers agree membership is a good idea.
+- The new member has supported the project several times, either through code
+  or otherwise, and has demonstrated a willingness to help solve other people's
+  problems, not just their own.
+- The new member demonstrates some degree of familiarity of open source
+  practices and online courtesy.
 
 ## Core developers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -73,7 +73,7 @@ The steering council is currently fixed in size to five members. This number may
 the future, but will always be an odd number to ensure a simple majority vote outcome
 is always possible. The initial steering council of zarr consists of
 
-* [Ryan Abernathy](https://github.com/rabernat)
+* [Ryan Abernathey](https://github.com/rabernat)
 
 * [John Kirkham](https://github.com/jakirkham)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Zask Governance
+
+This repository is for developing the governance model for the Zarr
+organization.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zask Governance
+# Zarr Governance
 
 This repository is for developing the governance model for the Zarr
 organization.


### PR DESCRIPTION
After a :thumbsup: from @alimanfoo (as his head's quite rightly down in epidemiological matters), I'd like to propose an initial governance process to formalize the _ad hoc_ one we've been following to keep the [EOSS](https://github.com/zarr-developers/community/issues/22) funding ticking along. Hopefully it speaks largely for itself but:

1. GOVERNANCE.md and CORE_DEVS_GUIDE.md are copied from [napari](https://github.com/napari/napari/blob/master/docs/developers/GOVERNANCE.md) (with thanks to @sofroniewn, @jni, & @royerloic). 
2. ~There are a few discussion points marked `"TBD"` mostly around use of google groups vs. GitHub team messages.~
3. I'd propose feedback should be before **April 15th**, though with the state of the world as it is, if there doesn't seem to be a euphorias consensus by that time, I'll extend and reach out to current devs individually (assuming I'm well, etc. etc.)

In any event, stay safe. ~J


----

 * [x] Specify specific time windows (see comments)
 * [x] Define primary "API principles" repository (see TBDs)
 * [x] Fix CONTRIBUTING link or remove
 * [x] Fix CORE_DEV_GUIDE link or remove
 * [x] Fix MISSIONS_AND_VALUES links or remove
 * [x] Choose google groups, GitHub messages, etc. for primary communication
 

