### PR TITLE
Create Implementation Council

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-council-invite.md
+++ b/.github/ISSUE_TEMPLATE/implementation-council-invite.md
@@ -1,0 +1,53 @@
+---
+title: Invitation to Zarr Implementation Council (${COMMUNITY})
+labels: ZIC
+assignees: @zarr-developers/steering-council
+---
+
+<!--
+Invitation to be sent to implementation communities:
+
+This file contains a template for the invitation that will be sent to
+implementation communities to join the Implementation Council.
+-->
+
+## Introduction
+
+Changes to the Zarr specification impact all implementors. In order to manage
+that burden, the Zarr project has formed an implementation council. Each
+implementation community selects one person to sit on the council to help shape
+changes to the Zarr spec.
+
+## Rights & Responsibilities
+
+The hope is that sitting on the council is itself a minimal additional burden.
+Each decision to be made will be encapsulated as a "ZEP" (Zarr Enhancement
+Process) which will need to be voted on. Each community can state that they
+intend to actively implement ("YES") that they might eventually implement
+("ABSTRAIN") or that they will never implement ("VETO").
+
+Members of the Implementation Council will be added to the similarly named
+team on GitHub which has privileges on the zarr-specs and zep repos.
+
+## Next steps
+
+First, if you would like to read more on the council and the process surrounding it,
+please see
+the [Governance document](https://github.com/zarr-developers/governance/blob/74d6f3fcd98ee76c5807d0f8754a195a3ce18876/GOVERNANCE.md#implementation-council)
+as well as the [ZEP](https://github.com/zarr-developers/governance/blob/1d2f3989896955c8bff8dc8d3d03f7580eaa474e/ZEP/instructions/zep0000.md) itself.
+for more information.
+
+Then, please use this issue to let the steering council either:
+ * that you are not interested or perhaps do not have the capacity at this time
+ * or to assign your council representative.
+
+If any help or discussion is needed, feel free to do so here or link to other
+issues/threads as necessary.
+
+Finally, we invite any implementation that has joined the Implementation
+Council to also host their implementation's repositories in the zarr-developers
+GitHub organization. This is not mandatory and has no impact on voting rights.
+Most importantly, we would like to show the vibrancy of the Zarr community
+and the strength that comes from a larger number of implementations.
+
+Thanks to all of you!

--- a/.github/ISSUE_TEMPLATE/implementation-council-invite.md
+++ b/.github/ISSUE_TEMPLATE/implementation-council-invite.md
@@ -37,9 +37,9 @@ the [Governance document](https://github.com/zarr-developers/governance/blob/74d
 as well as the [ZEP](https://github.com/zarr-developers/governance/blob/1d2f3989896955c8bff8dc8d3d03f7580eaa474e/ZEP/instructions/zep0000.md) itself.
 for more information.
 
-Then, please use this issue to let the steering council either:
+Then, please use this issue to let the steering council know either:
  * that you are not interested or perhaps do not have the capacity at this time
- * or to assign your council representative.
+ * or whom you will be assigning as your council representative.
 
 If any help or discussion is needed, feel free to do so here or link to other
 issues/threads as necessary.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,6 +12,11 @@ resolved.
 
 # Roles And Responsibilities
 
+## The Project
+
+The Zarr project consists of the core Zarr specification and the various
+implementations of Zarr in different programming languages.
+
 ## The Community
 
 The Zarr community consists of anyone using or working with the project
@@ -36,30 +41,36 @@ can directly help to shape its future.
 Potential contributors are encouraged to read the [Contributing Guide](http://zarr.readthedocs.io/en/stable/contributing.html)
 as well as the [Code of Conduct](https://github.com/zarr-developers/.github/blob/master/CODE_OF_CONDUCT.md).
 
-A community member becomes a contributor when the following criteria are met:
-
-- At least two core developers from separate employers agree membership is a good idea.
-- The new member has supported the project several times, either through code
-  or otherwise, and has demonstrated a willingness to help solve other people's
-  problems, not just their own.
-- The new member demonstrates some degree of familiarity of open source
-  practices and online courtesy.
+Anyone who has recently engaged with the project in these concrete ways, in compliance with
+the Contributing Guide and Code of Conduct, is considered a contributor.
 
 ## Core developers
 
 Core developers are community members that have demonstrated continued
-commitment to the project through ongoing contributions. They
-have shown they can be trusted to maintain Zarr with care. Becoming a
-core developer allows contributors to merge approved pull requests, cast votes
+commitment to the project through ongoing contributions to the specification,
+governance, and / or implementions of Zarr.
+The have shown they can be trusted to maintain the project with care.
+Each implementation has its own set of core developers.
+Becoming a core developer allows contributors to merge approved pull requests, cast votes
 for and against merging a pull-request, and be involved in deciding major
 changes to the API, and thereby more easily carry on with their project related
 activities. Core developers appear as organization members on the Zarr
-[GitHub organization](https://github.com/orgs/zarr-developers/people) and are on our
-[@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team. Core
-developers are expected to review code contributions while adhering to the
+[GitHub organization](https://github.com/orgs/zarr-developers/people).
+All core develoipes belong to the
+[@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team
+as well as one or more implementation-specific sub-teams.
+Core  developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
-by any existing core developer, and for details on that process see our core
-developer guide.
+by any existing core developer.
+For details on that process see our core developer guide.
+
+## Implementation Council
+
+The Core Developers of each implementation will nominate one representative to the Zarr
+implementation council.
+This member will represent that implementation in decisions regarding the Zarr Specification
+and other Zarr-wide contexts which require input from implementations.
+It is up to each implementation to determine its own process for nominating its representative.
 
 ## Steering Council
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -62,11 +62,10 @@ activities. Core developers appear as organization members on the Zarr
 [GitHub organization](https://github.com/orgs/zarr-developers/people).
 All core developers belong to the
 [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team
-as well as one or more implementation-specific sub-teams.
+either directly or via one or more implementation-specific sub-teams.
 Core developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
-by any existing core developer.
-For details on that process see our core developer guide.
+by any existing core developer. For details on that process see our core developer guide.
 
 ## Implementation Council
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,45 +67,17 @@ Core developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
 by any existing core developer. For details on that process see our core developer guide.
 
-## Implementation Council
+## Zarr Steering Council
 
-The Zarr steering council will invite Zarr implementations participate in the
-management of the Zarr specification. Implementations will be selected based
-on maturity of implementation as well as the activity of the developer community.
-Preference will be given to open source *and open process* implementations.
-Multiple implementations in a single programming language may be invited, or
-such implementations could choose to work together as a single community.
-
-The current list of implementations which are participating in this process are:
-
- * TBD...
-
-The Core developers of each implementation will select one representative to
-the Zarr implementation council. It is up to each implementation to determine
-its own process for selecting its representatives.
-
-This member will represent that implementation in decisions regarding the Zarr
-Specification and other Zarr-wide contexts which require input from
-implementations.
-
-An additional representation should also be selected to act as an alternate
-for when the primary representative is not reachable.
-
-Continued membership on the council is dependent on timely feedback and votes
-on relevant issues. The steering council also reserves the right to remove
-implementations from the council.
-
-## Steering Council
-
-The Steering Council (SC) members are core developers who have additional
-responsibilities to ensure the smooth running of the project. SC members are
+The Zarr Steering Council (ZSC) members are core developers who have additional
+responsibilities to ensure the smooth running of the project. ZSC members are
 expected to participate in strategic planning, approve changes to the
 governance model, and make decisions about funding granted to the project
 itself. (Funding to community members is theirs to pursue and manage). The
-purpose of the SC is to ensure smooth progress from the big-picture
+purpose of the ZSC is to ensure smooth progress from the big-picture
 perspective. Changes that impact the full project require analysis informed by
 long experience with both the project and the larger ecosystem. When the core
-developer community (including the SC members) fails to reach such a consensus
+developer community (including the ZSC members) fails to reach such a consensus
 in a reasonable timeframe, the SC is the entity that resolves the issue.
 
 Members of the steering council also have the "owner" role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
@@ -136,6 +108,35 @@ be postponed until the new member has joined and another vote can be held.
 
 The Zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`,
 or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team.
+
+## Zarr Implementation Council (ZIC)
+
+The ZSC will invite Zarr implementations to participate in the management of the
+Zarr specification through the Zarr Implementation Council (ZIC).
+Implementations will be selected based on maturity of implementation as well as
+the activity of the developer community.  Preference will be given to open
+source *and open process* implementations.  Multiple implementations in a single
+programming language may be invited, or such implementations could choose to
+work together as a single community.
+
+The current list of implementations which are participating in this process are:
+
+ * TBD...
+
+The Core developers of each implementation will select one representative to the
+ZIC. It is up to each implementation to determine its own process for selecting
+its representatives.
+
+This member will represent that implementation in decisions regarding the Zarr
+Specification and other Zarr-wide contexts which require input from
+implementations.
+
+An additional representative should also be selected to act as an alternate
+for when the primary representative is not reachable.
+
+Continued membership on the ZIC is dependent on timely feedback and votes on
+relevant issues. The ZSC also reserves the right to remove implementations from
+the council.
 
 # Decision Making Process
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,7 +15,9 @@ resolved.
 ## The Project
 
 The Zarr project consists of the core Zarr specification and the various
-implementations of Zarr in different programming languages.
+implementations of Zarr in different programming languages that are hosted
+within this organization. Other community implementations exist but do not
+follow this governance process.
 
 ## The Community
 
@@ -42,7 +44,9 @@ Potential contributors are encouraged to read the [Contributing Guide](http://za
 as well as the [Code of Conduct](https://github.com/zarr-developers/.github/blob/master/CODE_OF_CONDUCT.md).
 
 Anyone who has recently engaged with the project in these concrete ways, in compliance with
-the Contributing Guide and Code of Conduct, is considered a contributor.
+the Contributing Guide and Code of Conduct, is considered a contributor and can request
+to be added to the relevant GitHub team. Alternatively, any existing member
+of the community can invite a contributor to join.
 
 ## Core developers
 
@@ -56,21 +60,41 @@ for and against merging a pull-request, and be involved in deciding major
 changes to the API, and thereby more easily carry on with their project related
 activities. Core developers appear as organization members on the Zarr
 [GitHub organization](https://github.com/orgs/zarr-developers/people).
-All core develoipes belong to the
+All core developers belong to the
 [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team
 as well as one or more implementation-specific sub-teams.
-Core  developers are expected to review code contributions while adhering to the
+Core developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
 by any existing core developer.
 For details on that process see our core developer guide.
 
 ## Implementation Council
 
-The Core Developers of each implementation will nominate one representative to the Zarr
-implementation council.
-This member will represent that implementation in decisions regarding the Zarr Specification
-and other Zarr-wide contexts which require input from implementations.
-It is up to each implementation to determine its own process for nominating its representative.
+The Zarr steering council will invite Zarr implementations participate in the
+management of the Zarr specification. Implementations will be selected based
+on maturity of implementation as well as the activity of the developer community.
+Preference will be given to open source *and open process* implementations.
+Multiple implementations in a single programming language may be invited, or
+such implementations could choose to work together as a single community.
+
+The current list of implementations which are participating in this process are:
+
+ * TBD...
+
+The Core developers of each implementation will select one representative to
+the Zarr implementation council. It is up to each implementation to determine
+its own process for selecting its representatives.
+
+This member will represent that implementation in decisions regarding the Zarr
+Specification and other Zarr-wide contexts which require input from
+implementations.
+
+An additional representation should also be selected to act as an alternate
+for when the primary representative is not reachable.
+
+Continued membership on the council is dependent on timely feedback and votes
+on relevant issues. The steering council also reserves the right to remove
+implementations from the council.
 
 ## Steering Council
 


### PR DESCRIPTION
Here I am proposing we create a Zarr Implementation Council. I am also trying to make the language of our governance more reflective of the "one spec / many implementations" state of Zarr. There is not just one set of "core developers"; instead, each implementation has its own core developers. 

To go along with this change, I would suggest we invite existing implementations into the zarr-developers GitHub organization and create teams for their core devs.

Having an Implementation Council will help with the ZEP process being discussed in #16.