### PR TITLE
Mention ZEP process in the GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -197,7 +197,7 @@ flaws that they can live with and not hold up the decision-making process for
 the latter. If no option can be found without objections, the decision is
 escalated to the ZSC, which will use consensus to come to a resolution. In the
 unlikely event that there is still a deadlock, the proposal will move forward
-if it has the support of a simple majority of the SC.
+if it has the support of a simple majority of the ZSC.
 
 Decisions (in addition to adding core developers, ZIC representative(s) and SC
 membership as above) are made according to the following rules:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,10 +14,11 @@ resolved.
 
 ## The Project
 
-The Zarr project consists of the core Zarr specification and the various
-implementations of Zarr in different programming languages that are hosted
-within this organization. Other community implementations exist but do not
-follow this governance process.
+The Zarr project consists of the core [Zarr specification](https://github.com/zarr-developers/zarr-specs/)
+and the various [implementations](https://github.com/zarr-developers/zarr_implementations/)
+of Zarr in different programming languages that are hosted within this
+organization. Other community implementations exist but do not follow this
+governance process.
 
 ## The Community
 
@@ -188,18 +189,18 @@ https://github.com/orgs/zarr-developers/teams/core-devs
 
 Decisions should be made in accordance with the mission and values of the Zarr project.
 
-Zarr uses a “consensus seeking” process for making decisions. The group
-tries to find a resolution that has no open objections among core developers.
-Core developers are expected to distinguish between fundamental objections to a
-proposal and minor perceived flaws that they can live with, and not hold up the
-decision-making process for the latter.  If no option can be found without
-objections, the decision is escalated to the SC, which will itself use
-consensus seeking to come to a resolution. In the unlikely event that there is
-still a deadlock, the proposal will move forward if it has the support of a
-simple majority of the SC.
+Zarr uses a “consensus seeking” process for making decisions. The group tries to
+find a resolution that has no open objections among core developers and ZIC.
+Core developers and ZIC are expected to distinguish between fundamental
+objections to a proposal and minor perceived flaws that they can live with, and
+not hold up the decision-making process for the latter.  If no option can be
+found without objections, the decision is escalated to the SC, which will
+itself use consensus seeking to come to a resolution. In the unlikely event
+that there is still a deadlock, the proposal will move forward if it has the
+support of a simple majority of the SC.
 
-Decisions (in addition to adding core developers and SC membership as above)
-are made according to the following rules:
+Decisions (in addition to adding core developers, ZIC representative(s) and SC
+membership as above) are made according to the following rules:
 
 - **Minor documentation changes**, such as typo fixes, or addition / correction of a
   sentence, require approval by a core developer *and* no disagreement or requested
@@ -220,15 +221,15 @@ are made according to the following rules:
   decision-making process outlined above, though "reasonable time" is likely extended
   to at least a week.
 
-- **Changes to the specification** require a dedicated issue on our
-  [issue tracker](https://github.com/zarr-developers/zarr-specs/issues) and even more
-  time than an API change. The appropriate length of time is currently under discussion.
+- **Changes to the specification** follow the [ZEP](https://zarr.dev/zeps)
+  process. Please read [ZEP0000](https://zarr.dev/zeps/active/ZEP0000.html)
+  for details and instructions to submit a new ZEP.
 
 - **Changes to this governance model or our mission, vision, and values**
   require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)
-  and follow the decision-making process outlined above, with "reasonable time" being
-  at least two weeks. However, if there is unanimous agreement from core developers on the change,
-  it can move forward faster.
+  and follow the [ZEP](https://zarr.dev/zeps) process, with "reasonable time"
+  being at least two weeks. However, if there is unanimous agreement from core
+  developers on the change, it can move forward faster.
 
 If an objection is raised on a lazy consensus, the proposer can appeal to the
 community and core developers and the change can be approved or rejected by

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -199,7 +199,7 @@ escalated to the ZSC, which will use consensus to come to a resolution. In the
 unlikely event that there is still a deadlock, the proposal will move forward
 if it has the support of a simple majority of the ZSC.
 
-Decisions (in addition to adding core developers, ZIC representative(s) and SC
+Decisions (in addition to adding core developers, ZIC representative(s) and ZSC
 membership as above) are made according to the following rules:
 
 - **Minor documentation changes**, such as typo fixes, or addition / correction of a

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,7 +15,7 @@ resolved.
 ## The Project
 
 The Zarr project consists of the core [Zarr specification](https://github.com/zarr-developers/zarr-specs/)
-and the various [implementations](https://github.com/zarr-developers/zarr_implementations/)
+and the various [implementations](https://zarr.dev/implementations/)
 of Zarr in different programming languages that are hosted within this
 organization. Other community implementations exist but do not follow this
 governance process.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -42,7 +42,7 @@ all are encouraged to do so. By contributing to the project, community members
 can directly help to shape its future.
 
 Potential contributors are encouraged to read the [Contributing Guide](http://zarr.readthedocs.io/en/stable/contributing.html)
-as well as the [Code of Conduct](https://github.com/zarr-developers/.github/blob/main/CODE_OF_CONDUCT.md).
+as well as the [CODE OF CONDUCT](https://github.com/zarr-developers/.github/blob/main/CODE_OF_CONDUCT.md).
 
 Anyone who has recently engaged with the project in these concrete ways, in compliance with
 the Contributing Guide and Code of Conduct, is considered a contributor and can request
@@ -189,15 +189,15 @@ https://github.com/orgs/zarr-developers/teams/core-devs
 
 Decisions should be made in accordance with the mission and values of the Zarr project.
 
-Zarr uses a “consensus seeking” process for making decisions. The group tries to
-find a resolution that has no open objections among core developers and ZIC.
-Core developers and ZIC are expected to distinguish between fundamental
-objections to a proposal and minor perceived flaws that they can live with, and
-not hold up the decision-making process for the latter.  If no option can be
-found without objections, the decision is escalated to the SC, which will
-itself use consensus seeking to come to a resolution. In the unlikely event
-that there is still a deadlock, the proposal will move forward if it has the
-support of a simple majority of the SC.
+Zarr uses a “consensus-seeking” process for making decisions. The group tries to
+find a resolution that has no open objections among core developers and ZIC
+representatives. Core developers and ZIC representatives are expected to
+distinguish between fundamental objections to a proposal and minor perceived
+flaws that they can live with and not hold up the decision-making process for
+the latter. If no option can be found without objections, the decision is
+escalated to the SC, which will use consensus to come to a resolution. In the
+unlikely event that there is still a deadlock, the proposal will move forward
+if it has the support of a simple majority of the SC.
 
 Decisions (in addition to adding core developers, ZIC representative(s) and SC
 membership as above) are made according to the following rules:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -83,7 +83,7 @@ in a reasonable timeframe, the SC is the entity that resolves the issue.
 
 Members of the steering council also have the "owner" role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
 and are ultimately responsible for managing the [zarr-developers](https://github.com/zarr-developers) GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
-twitter account, the [Zarr website]( https://zarr-developers.github.io), and other similar Zarr-owned resources.
+twitter account, the [Zarr website](https://zarr-developers.github.io), and other similar Zarr-owned resources.
 
 The steering council is currently fixed in size to five members. This number may be increased in
 the future, but will always be an odd number to ensure a simple majority vote outcome
@@ -190,17 +190,17 @@ https://github.com/orgs/zarr-developers/teams/core-devs
 Decisions should be made in accordance with the mission and values of the Zarr project.
 
 Zarr uses a “consensus-seeking” process for making decisions. The group tries to
-find a resolution that has no open objections among core developers and ZIC
-representatives. Core developers and ZIC representatives are expected to
-distinguish between fundamental objections to a proposal and minor perceived
-flaws that they can live with and not hold up the decision-making process for
-the latter. If no option can be found without objections, the decision is
-escalated to the ZSC, which will use consensus to come to a resolution. In the
-unlikely event that there is still a deadlock, the proposal will move forward
-if it has the support of a simple majority of the ZSC.
+find a resolution that has no open objections among core developers. Core
+developers are expected to distinguish between fundamental objections to a
+proposal and minor perceived flaws that they can live with and not hold up the
+decision-making process for the latter. If no option can be found without
+objections, the decision is escalated to the SC, which will use consensus to
+come to a resolution. In the unlikely event that there is still a deadlock, the
+proposal will move forward if it has the support of a simple majority of the
+SC.
 
-Decisions (in addition to adding core developers, ZIC representative(s) and ZSC
-membership as above) are made according to the following rules:
+Decisions (in addition to adding core developers and SC membership as above) are
+made according to the following rules:
 
 - **Minor documentation changes**, such as typo fixes, or addition / correction of a
   sentence, require approval by a core developer *and* no disagreement or requested

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -197,7 +197,7 @@ decision-making process for the latter. If no option can be found without
 objections, the decision is escalated to the SC, which will use consensus to
 come to a resolution. In the unlikely event that there is still a deadlock, the
 proposal will move forward if it has the support of a simple majority of the
-SC.
+ZSC.
 
 Decisions (in addition to adding core developers and SC membership as above) are
 made according to the following rules:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -195,7 +195,7 @@ representatives. Core developers and ZIC representatives are expected to
 distinguish between fundamental objections to a proposal and minor perceived
 flaws that they can live with and not hold up the decision-making process for
 the latter. If no option can be found without objections, the decision is
-escalated to the SC, which will use consensus to come to a resolution. In the
+escalated to the ZSC, which will use consensus to come to a resolution. In the
 unlikely event that there is still a deadlock, the proposal will move forward
 if it has the support of a simple majority of the SC.
 


### PR DESCRIPTION
Hi all. 🙋🏻‍♂️

Since we're using the [ZEP](https://zarr.dev/zeps) for the specification and other process changes to the Zarr, I've mentioned the `ZEP` process in the governance document.

CC: @zarr-developers/steering-council 