### PR TITLE
transition representer role for zarr-js

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -131,7 +131,7 @@ The current list of implementations which are participating in this process are
     ([May 2022 – present](https://github.com/zarr-developers/governance/issues/22))
 
  * [freeman-lab/zarr-js](https://github.com/freeman-lab/zarr-js)
-    represented by [Jeremy Freeman](https://github.com/freeman-lab)
+    represented by [Anderson Banihirwe](https://github.com/andersy005)
     ([May 2022 – present](https://github.com/zarr-developers/governance/issues/27))
 
  * [gzuidhof/zarr.js](https://github.com/gzuidhof/zarr.js)


### PR DESCRIPTION
this pull request transitions the representer role for zarr-js from @freeman-lab to @andersy005.

Cc @joshmoore 