### PR TITLE
Update zarr-python represenation on ZIC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -161,8 +161,9 @@ The current list of implementations which are participating in this process are
    ([May 2022 - present](https://github.com/zarr-developers/governance/issues/23))
 
  * [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
-   represented by [Gregory Lee](https://github.com/grlee77)
-   ([May 2022 - present](https://github.com/zarr-developers/governance/issues/19))
+   represented by [Joe Hamman](https://github.com/jhamman)
+   (Jan 2024 - present) and seconded by
+   [Davis Bennett](https://github.com/d-v-b)
 
 The Core developers of each implementation will select one representative to the
 ZIC. It is up to each implementation to determine its own process for selecting


### PR DESCRIPTION
Welcome to @jhamman as a new ZIC representation for zarr-python and @d-v-b as his second in cases where he is unavailable for a vote. This change matches the development of a new ZEP1 implementation on the `v3` branch of the zarr-python repo, which re-integrates work from the zarrita implementation by @normanrz and others. 👏🏽  Very much looking forward to the upcoming release.

Many thanks to @grlee77 for his contributions to date.

Internal reference: https://groups.google.com/g/zarr-python-core-devs/c/sHsbWBOBHSs?pli=1