### PR TITLE
Update core-dev repo permissions

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,7 +67,7 @@ either directly or via one or more implementation-specific sub-teams.
 Core developer sub-teams are given the "admin" role within the repositories that they manage. 
 Core developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
-by any existing core developer. For details on that process see our core developer guide. 
+by any existing core developer. For details on that process see our core developer guide.
 
 ## Zarr Steering Council
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,9 +64,10 @@ activities. Core developers appear as organization members on the Zarr
 All core developers belong to the
 [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team
 either directly or via one or more implementation-specific sub-teams.
+Core developer sub-teams are given the "admin" role within the repositories that they manage. 
 Core developers are expected to review code contributions while adhering to the
 [core developer guide](CORE_DEV_GUIDE.md). New core developers can be nominated
-by any existing core developer. For details on that process see our core developer guide.
+by any existing core developer. For details on that process see our core developer guide. 
 
 ## Zarr Steering Council
 


### PR DESCRIPTION
Small change to specify what permissions core-dev sub-teams will be granted in the repositories that they manage.

See https://github.com/zarr-developers/zarr-python/issues/1905 and https://github.com/orgs/zarr-developers/discussions/70 for more discussion on the topic.

