### PR TITLE
Fix core dev description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository contains the governance model for the Zarr organization as
 well as other community health statements.
 
 * [GOVERNANCE.md](./governance.md) - decision making process
-* [CORE_DEV_GUIDE.md](./CORE_DEV_GUIDE.md) - getting started guide for contributors
+* [CORE_DEV_GUIDE.md](./CORE_DEV_GUIDE.md) - getting started guide for core developers
 * [DIVERSITY.md](./DIVERSITY.md) - diversity and inclusion statement
 * [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) - redirects to the GitHub-specific [covenant](https://github.com/zarr-developers/.github/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
I think this is what was intended? The linked document doesn't seem to be targeted at general contributors.