### PR TITLE
Add Norman to the ZSC for Ryan W.

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -98,7 +98,7 @@ is always possible. The initial steering council of Zarr consists of
 
 * [Josh Moore](https://github.com/joshmoore)
 
-* [Ryan Williams](https://github.com/ryan-williams)
+* [Norman Rzepka](https://github.com/normanrz)
 
 The SC membership is revisited every January. SC members who do
 not actively engage with the SC duties are expected to resign. New members are


### PR DESCRIPTION
 * @ryan-williams stepped down on October 14th via email to the ZSC mailing list.
 * @rabernat nominated @normanrz on November 14th via email to the ZSC mailing list.
 * @normanrz was unanimously added to the ZSC via monthly call on November 21st by the four remaining members.

Welcome, @normanrz, and many thanks, @ryan-williams, for your years of support!

I'm opening this PR so I can get a blog post ready and then post on https://bsky.app/profile/zarr.dev, https://www.linkedin.com/company/zarrdev/, etc.

cc: @zarr-developers/steering-council 