### PR TITLE
Update ZIC membership

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -124,17 +124,9 @@ work together as a single community.
 The current list of implementations which are participating in this process are
 (in alphabetical order)
 
- * [constantinpape/z5](https://github.com/constantinpape/z5)
-    represented by [Constantin Pape](https://github.com/constantinpape)
-    ([May 2022 – present](https://github.com/zarr-developers/governance/issues/26))
-
  * [google/tensorstore](https://github.com/google/tensorstore)
     represented by [Jeremy Maitin-Shepard](https://github.com/jbms)
     ([May 2022 – present](https://github.com/zarr-developers/governance/issues/22))
-
- * [freeman-lab/zarr-js](https://github.com/freeman-lab/zarr-js)
-    represented by [Anderson Banihirwe](https://github.com/andersy005)
-    ([May 2022 – present](https://github.com/zarr-developers/governance/issues/27))
 
  * [gzuidhof/zarr.js](https://github.com/gzuidhof/zarr.js)
     represented by [Trevor Manz](https://github.com/manzt)
@@ -148,23 +140,19 @@ The current list of implementations which are participating in this process are
    represented by [Stephan Saalfeld](https://github.com/axtimwalde)
    ([May 2022 – present](https://github.com/zarr-developers/governance/issues/25))
 
- * [sci-rs/zarr](https://github.com/sci-rs/zarr)
-   represented by [Andrew Champion](https://github.com/aschampion)
-   ([May 2022 - present](https://github.com/zarr-developers/governance/issues/20))
-
  * [Unidata/netcdf-c](https://github.com/Unidata/netcdf-c) and
    [Unidata/netcdf-java](https://github.com/Unidata/netcdf-java)
    represented by [Ward Fisher](https://github.com/wardf)
    ([May 2022 - present](https://github.com/zarr-developers/governance/issues/21))
 
- * [xtensor-stack/xtensor-zarr](https://github.com/xtensor-stack/xtensor-zarr)
-   represented by [David Brochart](https://github.com/davidbrochart)
-   ([May 2022 - present](https://github.com/zarr-developers/governance/issues/23))
-
  * [zarr-developers/zarr-python](https://github.com/zarr-developers/zarr-python)
    represented by [Joe Hamman](https://github.com/jhamman)
    (Jan 2024 - present) and seconded by
    [Davis Bennett](https://github.com/d-v-b)
+
+ * [LDeakin/zarrs](https://github.com/LDeakin/zarrs)
+   represented by [Lachlan Deakin](https://github.com/LDeakin)
+   (May 2025 - present) 
 
 The Core developers of each implementation will select one representative to the
 ZIC. It is up to each implementation to determine its own process for selecting


### PR DESCRIPTION
The @zarr-developers/steering-council council has reviewed the ZIC. We are removing four inactive Zarr implementations and adding one new one.

xref
- https://github.com/xtensor-stack/xtensor-zarr/issues/66
- https://github.com/constantinpape/z5/issues/235
- https://github.com/freeman-lab/zarr-js/issues/70
- private conversation with @aschampion on sci-rs/zarr
- private conversation with @ldeakin on zarrs